### PR TITLE
Add notation for v⇩D to fix parsing errors in reactive.

### DIFF
--- a/utp_des_core.thy
+++ b/utp_des_core.thy
@@ -8,6 +8,9 @@ alphabet des_vars =
 type_synonym ('s\<^sub>1, 's\<^sub>2) des_rel = "('s\<^sub>1 des_vars_scheme, 's\<^sub>2 des_vars_scheme) urel"
 type_synonym ('s\<^sub>1) des_hrel = "('s\<^sub>1, 's\<^sub>1) des_rel"
 
+
+notation des_vars.more\<^sub>L ("\<^bold>v\<^sub>D")
+
 syntax
   "_svid_des_alpha"  :: "svid" ("\<^bold>v\<^sub>D")
 


### PR DESCRIPTION
Add a notation declaration for v⇩D.

This is to prevent parsing errors in expressions such as `v⇩D ≈⇩L (wait +⇩L tr +⇩L ❙v⇩R)` in the reactive lemma des_lens_equiv_wait_tr_rest.